### PR TITLE
Polish nextLink from AppCenter response to include app owner and name when invalid URL is returned

### DIFF
--- a/tests/test_appcenter.py
+++ b/tests/test_appcenter.py
@@ -41,7 +41,11 @@ class LibraryTests(unittest.TestCase):
     def test_construction(self):
         """Test construction."""
         client = appcenter.AppCenterClient(access_token=LibraryTests.TOKEN)
-        start_time = datetime.datetime.now() - datetime.timedelta(days=10)
+        start_time = datetime.datetime.now() - datetime.timedelta(days=10)        
+        # Test to fetch at least 2 error group batches
+        ERROR_GROUP_BATCH_LIMIT = 2
+        error_group_batch_count = 0
+
         for group in client.crashes.get_error_groups(
             owner_name=LibraryTests.OWNER_NAME,
             app_name=LibraryTests.APP_NAME,
@@ -86,7 +90,11 @@ class LibraryTests(unittest.TestCase):
                 break
 
             self.assertTrue(has_errors)
-            break
+
+            error_group_batch_count += 1
+            
+            if error_group_batch_count == ERROR_GROUP_BATCH_LIMIT:
+                break
 
     def test_recent(self):
         """Test recent."""


### PR DESCRIPTION
**Overview**
AppCenter API returns invalid `nextLink` values when doing batch requests. There are two issues currently encountered:
1. The substring `api/` make the next batch request fail (this is a known issue and a work around was already in code)
2. For some apps, `app_owner` and `app_name` are no longer included in the next link to use.
   - Example of response: `"nextLink": "/api/v0.1/apps//errors/errorGroups?`

**What does this PR do?**
- Adds new method `next_link_polished` to work around the two issues. It's not ideal but we can't wait on AppCenter support
- Replace old work-around with calls to new private helper method
- Updates UTs to at least make two batch requests of `error_groups` and test this new scenario