### PR TITLE
Update models.py to mark app_icon_url as Optional

### DIFF
--- a/appcenter/models.py
+++ b/appcenter/models.py
@@ -305,7 +305,7 @@ class ReleaseDetailsResponse:
     download_url: Optional[str]
 
     # A URL to the app's icon.
-    app_icon_url: str
+    app_icon_url: Optional[str]
 
     # The href required to install a release on a mobile device. On iOS devices will be prefixed
     # with itms-services://?action=download-manifest&url=


### PR DESCRIPTION
@dalemyers Please take a look!

When you create an app on AppCenter, adding an App Icon is optional. However the schema for `ReleaseDetailsResponse` for this module assumes that it will be non-null. This results in a failure to successfully query the app during the upload process.

Example stack trace we run into:
```
Traceback (most recent call last):
  File "$REDACTED/buck-out/gen/scripts/feature-app/__upload__/sh_binary.R1KZJ8fNQC/__default__/scripts/feature-app/upload", line 184, in <module>
    main()
  File "$REDACTED/buck-out/gen/scripts/feature-app/__upload__/sh_binary.R1KZJ8fNQC/__default__/scripts/feature-app/upload", line 182, in main
    upload_to_appcenter(args.ipa, args.appcenter_name, args.owner, args.appcenter_api_token, args.release_notes, args.distribution_group)
  File "$REDACTED/buck-out/gen/scripts/feature-app/__upload__/sh_binary.R1KZJ8fNQC/__default__/scripts/feature-app/upload", line 153, in upload_to_appcenter
    client.versions.upload_and_release(
  File "$REDACTED/Library/Python/3.8/lib/python/site-packages/appcenter/versions.py", line 670, in upload_and_release
    return self.release_details(owner_name=owner_name, app_name=app_name, release_id=release_id)
  File "$REDACTED/Library/Python/3.8/lib/python/site-packages/appcenter/versions.py", line 132, in release_details
    return deserialize.deserialize(ReleaseDetailsResponse, response.json())
  File "$REDACTED/Library/Python/3.8/lib/python/site-packages/deserialize/__init__.py", line 93, in deserialize
    return _deserialize(
  File "$REDACTED/Library/Python/3.8/lib/python/site-packages/deserialize/__init__.py", line 175, in _deserialize
    _deserialize_dict(
  File "$REDACTED/Library/Python/3.8/lib/python/site-packages/deserialize/__init__.py", line 387, in _deserialize_dict
    raise DeserializeException(
deserialize.exceptions.DeserializeException: Unexpected missing value for: ReleaseDetailsResponse.app_icon_url
```

This PR simply updates the `ReleaseDetailsResponse` model to indicate that the `app_icon_url` is optional. In practice, this module isn't even using this property value.