### PR TITLE
fix incorrect return type for `AppCenterVersionsClient.all`

### DIFF
--- a/appcenter/versions.py
+++ b/appcenter/versions.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import time
-from typing import Iterator, List, Optional
+from typing import List, Optional
 import urllib.parse
 
 import deserialize
@@ -81,7 +81,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         app_name: str,
         published_only: bool = False,
         scope: Optional[str] = None,
-    ) -> Iterator[BasicReleaseDetailsResponse]:
+    ) -> List[BasicReleaseDetailsResponse]:
         """Get all (the 100 latest) versions.
 
         :param str owner_name: The name of the app account owner


### PR DESCRIPTION
it returns a `list`, not an `Iterator`, and `list` is not a subtype of `Iterator`

```py
from typing import Iterator

foo: Iterator[int] = [1]
next(foo)
```
```
> mypy asdf.py
asdf.py:3:22: error: Incompatible types in assignment (expression has type "list[int]", variable has type "Iterator[int]")  [assignment]
asdf.py:3:22: note: "list" is missing following "Iterator" protocol member:
asdf.py:3:22: note:     __next__
Found 1 error in 1 file (checked 1 source file)
```