### PR TITLE
Add required build_version parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ for version in client.versions.all(owner_name="owner", app_name="myapp"):
 client.versions.upload_and_release(
     owner_name="owner",
     app_name="myapp",
-    version="0.1",
-    build_number="123",
     binary_path="/path/to/some.ipa",
     group_id="12345678-abcd-9012-efgh-345678901234",
     release_notes="These are some release notes",
+    build_version="0.1",
+    notify_testers=True,
     branch_name="test_branch",
     commit_hash="1234567890123456789012345678901234567890",
     commit_message="This is a commit message"

--- a/appcenter/versions.py
+++ b/appcenter/versions.py
@@ -43,6 +43,7 @@ MIME_TYPES = {
     "msixbundle": "application/x-msixbundle",
     "msixupload": "application/x-msixupload",
     "msixsym": "application/x-msixupload",
+    "zip": "application/zip",
 }
 
 
@@ -180,12 +181,13 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         return None
 
     def get_upload_url(
-        self, *, owner_name: str, app_name: str
+        self, *, owner_name: str, app_name: str, build_version: str
     ) -> CreateReleaseUploadResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
         :param str owner_name: The name of the app account owner
         :param str app_name: The name of the app
+        :param srt build_version: The user defined build version of the app
 
         :returns: The App Center release identifier
         """
@@ -196,7 +198,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in get_upload_url")
             try:
-                response = self.post(request_url, data={})
+                response = self.post(request_url, data={"build_version": build_version})
                 if response.ok:
                     break
             except Exception as ex:
@@ -580,6 +582,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         app_name: str,
         binary_path: str,
         release_notes: str,
+        build_version: str,
         branch_name: Optional[str] = None,
         commit_hash: Optional[str] = None,
         commit_message: Optional[str] = None,
@@ -590,6 +593,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         :param str app_name: The name of the app
         :param str binary_path: The path to the binary to upload
         :param str release_notes: The release notes for the release
+        :param srt build_version: The user defined build version of the app
         :param Optional[str] branch_name: The git branch that the build came from
         :param Optional[str] commit_hash: The hash of the commit that was just built
         :param Optional[str] commit_message: The message of the commit that was just built
@@ -604,7 +608,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
             raise FileNotFoundError(f"Could not find binary: {binary_path}")
 
         create_release_upload_response = self.get_upload_url(
-            owner_name=owner_name, app_name=app_name
+            owner_name=owner_name, app_name=app_name, build_version=build_version
         )
 
         success = self.upload_binary(
@@ -656,6 +660,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         binary_path: str,
         group_id: str,
         release_notes: str,
+        build_version: str,
         notify_testers: Optional[bool] = None,
         branch_name: Optional[str] = None,
         commit_hash: Optional[str] = None,
@@ -668,6 +673,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         :param str binary_path: The path to the binary to upload
         :param str group_id: The ID of the group to release to
         :param str release_notes: The release notes for the release
+        :param srt build_version: The user defined build version of the app
         :param Optional[bool] notify_testers: Set to True to notify testers about this build
         :param Optional[str] branch_name: The git branch that the build came from
         :param Optional[str] commit_hash: The hash of the commit that was just built
@@ -684,6 +690,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
             app_name=app_name,
             binary_path=binary_path,
             release_notes=release_notes,
+            build_version=build_version,
             branch_name=branch_name,
             commit_hash=commit_hash,
             commit_message=commit_message,


### PR DESCRIPTION
Related to #25, but only addresses the underlying issue where uploads without `build_number` are rejected with the `A problem occured while extracting your app.` message.

Also fixed upload_and_release usage described in README.md
Added zip MIME type.