### PR TITLE
Fix cannot upload symbols

### DIFF
--- a/appcenter/crashes.py
+++ b/appcenter/crashes.py
@@ -410,6 +410,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
                 blob_name,
                 symbols_file,
                 BlobType.BLOCKBLOB,
+                overwrite=True,
                 progress_hook=progress_callback,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appcenter"
-version = "4.0.1"
+version = "4.0.2"
 description = "A Python wrapper around the App Center REST API."
 
 license = "MIT"


### PR DESCRIPTION
On #50 we migrated to use `upload_blob` to upload symbols, but this method will failed with `ResourceExistsError` error, this may because AppCenter pre-creates a blob when we call the `/symbol_uploads` API to begin upload, resulting the error that indicates that the resource already exists.

This PR add `overwrite=True` to fix the error.