### PR TITLE
Significant refactor to follow API design.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ client = appcenter.AppCenterClient(access_token="abc123def456")
 
 # 3. Check some error groups
 start = datetime.datetime.now() - datetime.timedelta(days=10)
-for group in client.crashes.get_error_groups(owner_name="owner", app_name="myapp", start_time=start):
+for group in client.crashes.get_error_groups(org_name="org", app_name="myapp", start_time=start):
     print(group.errorGroupId)
-    
+
 # 4. Get recent versions
-for version in client.versions.all(owner_name="owner", app_name="myapp"):
+for version in client.versions.all(org_name="org", app_name="myapp"):
     print(version)
-    
+
 # 5. Create a new release
 client.versions.upload_and_release(
-    owner_name="owner",
+    org_name="org",
     app_name="myapp",
     version="0.1",
     build_number="123",
@@ -37,7 +37,7 @@ client.versions.upload_and_release(
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 

--- a/appcenter/__init__.py
+++ b/appcenter/__init__.py
@@ -17,7 +17,7 @@ from appcenter.versions import AppCenterVersionsClient
 class AppCenterClient:
     """Class responsible for getting data from App Center through REST calls.
 
-    :param str access_token: The access token to use for authentication. Leave as None to use KeyVault
+    :param access_token: The access token to use for authentication. Leave as None to use KeyVault
     """
 
     log: logging.Logger

--- a/appcenter/__init__.py
+++ b/appcenter/__init__.py
@@ -7,9 +7,10 @@
 
 import logging
 
-from appcenter.account import AppCenterAccountClient
+from appcenter.apps import AppCenterAppsClient
 from appcenter.analytics import AppCenterAnalyticsClient
 from appcenter.crashes import AppCenterCrashesClient
+from appcenter.orgs import AppCenterOrgsClient
 from appcenter.tokens import AppCenterTokensClient
 from appcenter.versions import AppCenterVersionsClient
 
@@ -23,9 +24,10 @@ class AppCenterClient:
     log: logging.Logger
     token: str
 
-    account: AppCenterAccountClient
+    apps: AppCenterAppsClient
     analytics: AppCenterAnalyticsClient
     crashes: AppCenterCrashesClient
+    orgs: AppCenterOrgsClient
     tokens: AppCenterTokensClient
     versions: AppCenterVersionsClient
 
@@ -38,8 +40,9 @@ class AppCenterClient:
             self.log = parent_logger.getChild("appcenter")
 
         self.token = access_token
-        self.account = AppCenterAccountClient(self.token, self.log)
+        self.apps = AppCenterAppsClient(self.token, self.log)
         self.analytics = AppCenterAnalyticsClient(self.token, self.log)
         self.crashes = AppCenterCrashesClient(self.token, self.log)
+        self.orgs = AppCenterOrgsClient(self.token, self.log)
         self.tokens = AppCenterTokensClient(self.token, self.log)
         self.versions = AppCenterVersionsClient(self.token, self.log)

--- a/appcenter/account.py
+++ b/appcenter/account.py
@@ -29,69 +29,69 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def __init__(self, token: str, parent_logger: logging.Logger) -> None:
         super().__init__("account", token, parent_logger)
 
-    def users(self, *, owner_name: str, app_name: str) -> list[User]:
+    def users(self, *, org_name: str, app_name: str) -> list[User]:
         """Get the users for an app.
 
-        :param owner_name: The name of the app account owner
+        :param org_name: The name of the organization
         :param app_name: The name of the app. If not set, will get for org.
 
         :returns: A list of User
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/users"
 
         response = self.get(request_url)
 
         return deserialize.deserialize(list[User], response.json())
 
-    def org_users(self, *, owner_name: str) -> list[OrganizationUserResponse]:
+    def org_users(self, *, org_name: str) -> list[OrganizationUserResponse]:
         """Get the users in an org.
 
-        :param owner_name: The name of the app account owner
+        :param org_name: The name of the organization
 
         :returns: A list of OrganizationUserResponse
         """
 
-        request_url = self.generate_org_url(owner_name=owner_name)
+        request_url = self.generate_org_url(org_name=org_name)
         request_url += "/users"
 
         response = self.get(request_url)
 
         return deserialize.deserialize(list[OrganizationUserResponse], response.json())
 
-    def delete_user(self, *, owner_name: str, user_name: str) -> None:
+    def delete_user(self, *, org_name: str, user_name: str) -> None:
         """Delete a user from an org."""
 
-        request_url = self.generate_org_url(owner_name=owner_name) + f"/users/{user_name}"
+        request_url = self.generate_org_url(org_name=org_name) + f"/users/{user_name}"
 
         _ = self.delete(request_url)
 
-    def teams(self, *, owner_name: str) -> list[TeamResponse]:
+    def teams(self, *, org_name: str) -> list[TeamResponse]:
         """Get the teams in an org.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
 
         :returns: A TeamResponse
         """
 
-        request_url = self.generate_org_url(owner_name=owner_name)
+        request_url = self.generate_org_url(org_name=org_name)
         request_url += "/teams"
 
         response = self.get(request_url)
 
         return deserialize.deserialize(list[TeamResponse], response.json())
 
-    def team_users(self, *, owner_name: str, team_name: str) -> list[OrganizationUserResponse]:
+    def team_users(self, *, org_name: str, team_name: str) -> list[OrganizationUserResponse]:
         """Get the users in a team in an org.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str team_name: The name of the team
 
         :returns: A TeamResponse
         """
 
-        request_url = self.generate_org_url(owner_name=owner_name)
+        request_url = self.generate_org_url(org_name=org_name)
         request_url += f"/teams/{team_name}/users"
 
         response = self.get(request_url)
@@ -101,7 +101,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def add_collaborator(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         user_email: str,
         role: Role | None = None,
@@ -111,7 +111,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         If they are a new collaborator, they will be invited. If that is the
         case, the role must be specified.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str user_email: The email of the user
         :param Role | None role: The role the user should have (this is required for new users)
@@ -119,9 +119,9 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         :returns: The list of users
         """
 
-        self.log.info(f"Adding user {user_email} as collaborator on: {owner_name}/{app_name}")
+        self.log.info(f"Adding user {user_email} as collaborator on: {org_name}/{app_name}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/invitations"
 
         data = {"user_email": user_email}
@@ -131,27 +131,27 @@ class AppCenterAccountClient(AppCenterDerivedClient):
 
         self.post(request_url, data=data)
 
-    def delete_collaborator(self, *, owner_name: str, app_name: str, user_email: str) -> None:
+    def delete_collaborator(self, *, org_name: str, app_name: str, user_email: str) -> None:
         """Remove a user as a collaborator from an app.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str user_email: The email of the user to remove
         """
 
-        self.log.info(f"Deleting user {user_email} from: {owner_name}/{app_name}")
+        self.log.info(f"Deleting user {user_email} from: {org_name}/{app_name}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/users/{urllib.parse.quote(user_email)}"
 
         self.delete(request_url)
 
     def set_collaborator_permissions(
-        self, *, owner_name: str, app_name: str, user_email: str, permission: Permission
+        self, *, org_name: str, app_name: str, user_email: str, permission: Permission
     ) -> None:
         """Set a users collaborator permissions on an app.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str user_email: The email of the user
         :param Permission permission: The permission level to grant
@@ -161,23 +161,23 @@ class AppCenterAccountClient(AppCenterDerivedClient):
 
         self.log.info(
             f"Setting user {user_email} as collaborator with permission "
-            + f"{permission.value} on: {owner_name}/{app_name}"
+            + f"{permission.value} on: {org_name}/{app_name}"
         )
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/users/{urllib.parse.quote(user_email)}"
 
         self.patch(request_url, data={"permissions": [permission.value]})
 
-    def apps(self, *, owner_name: str) -> list[AppResponse]:
+    def apps(self, *, org_name: str) -> list[AppResponse]:
         """Get the apps in an org.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
 
         :returns: A list of AppResponse
         """
 
-        request_url = self.generate_org_url(owner_name=owner_name)
+        request_url = self.generate_org_url(org_name=org_name)
         request_url += "/apps"
 
         response = self.get(request_url)

--- a/appcenter/account.py
+++ b/appcenter/account.py
@@ -70,7 +70,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def teams(self, *, org_name: str) -> list[TeamResponse]:
         """Get the teams in an org.
 
-        :param str org_name: The name of the organization
+        :param org_name: The name of the organization
 
         :returns: A TeamResponse
         """
@@ -85,8 +85,8 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def team_users(self, *, org_name: str, team_name: str) -> list[OrganizationUserResponse]:
         """Get the users in a team in an org.
 
-        :param str org_name: The name of the organization
-        :param str team_name: The name of the team
+        :param org_name: The name of the organization
+        :param team_name: The name of the team
 
         :returns: A TeamResponse
         """
@@ -111,10 +111,10 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         If they are a new collaborator, they will be invited. If that is the
         case, the role must be specified.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str user_email: The email of the user
-        :param Role | None role: The role the user should have (this is required for new users)
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param user_email: The email of the user
+        :param role: The role the user should have (this is required for new users)
 
         :returns: The list of users
         """
@@ -134,9 +134,9 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def delete_collaborator(self, *, org_name: str, app_name: str, user_email: str) -> None:
         """Remove a user as a collaborator from an app.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str user_email: The email of the user to remove
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param user_email: The email of the user to remove
         """
 
         self.log.info(f"Deleting user {user_email} from: {org_name}/{app_name}")
@@ -151,10 +151,10 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     ) -> None:
         """Set a users collaborator permissions on an app.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str user_email: The email of the user
-        :param Permission permission: The permission level to grant
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param user_email: The email of the user
+        :param permission: The permission level to grant
 
         :returns: The list of users
         """
@@ -172,7 +172,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
     def apps(self, *, org_name: str) -> list[AppResponse]:
         """Get the apps in an org.
 
-        :param str org_name: The name of the organization
+        :param org_name: The name of the organization
 
         :returns: A list of AppResponse
         """

--- a/appcenter/analytics.py
+++ b/appcenter/analytics.py
@@ -30,9 +30,9 @@ class AppCenterAnalyticsClient(AppCenterDerivedClient):
     ) -> ReleaseCounts:
         """Get the release counts for an app
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param list[ReleaseWithDistributionGroup] releases: The list of releases to get the counts for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param releases: The list of releases to get the counts for
 
         :returns: The release counts
         """

--- a/appcenter/analytics.py
+++ b/appcenter/analytics.py
@@ -51,6 +51,6 @@ class AppCenterAnalyticsClient(AppCenterDerivedClient):
                 }
             )
 
-        response = self.post(request_url, data={"releases": data})
+        response = self.http_post(request_url, data={"releases": data})
 
         return deserialize.deserialize(ReleaseCounts, response.json())

--- a/appcenter/analytics.py
+++ b/appcenter/analytics.py
@@ -24,22 +24,22 @@ class AppCenterAnalyticsClient(AppCenterDerivedClient):
     def release_counts(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         releases: list[ReleaseWithDistributionGroup],
     ) -> ReleaseCounts:
         """Get the release counts for an app
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param list[ReleaseWithDistributionGroup] releases: The list of releases to get the counts for
 
         :returns: The release counts
         """
 
-        self.log.info(f"Getting release counts for: {owner_name}/{app_name}")
+        self.log.info(f"Getting release counts for: {org_name}/{app_name}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/analytics/distribution/release_counts"
 
         data = []

--- a/appcenter/apps.py
+++ b/appcenter/apps.py
@@ -9,31 +9,24 @@ import urllib.parse
 import deserialize
 
 from appcenter.derived_client import AppCenterDerivedClient
-from appcenter.models import (
-    OrganizationUserResponse,
-    TeamResponse,
-    User,
-    Permission,
-    Role,
-    AppResponse,
-)
+from appcenter.models import User, Permission, Role, AppTeamResponse
 
 
-class AppCenterAccountClient(AppCenterDerivedClient):
-    """Wrapper around the App Center account APIs.
+class AppCenterAppsClient(AppCenterDerivedClient):
+    """Wrapper around the App Center app APIs.
 
     :param token: The authentication token
     :param parent_logger: The parent logger that we will use for our own logging
     """
 
     def __init__(self, token: str, parent_logger: logging.Logger) -> None:
-        super().__init__("account", token, parent_logger)
+        super().__init__("app", token, parent_logger)
 
     def users(self, *, org_name: str, app_name: str) -> list[User]:
         """Get the users for an app.
 
         :param org_name: The name of the organization
-        :param app_name: The name of the app. If not set, will get for org.
+        :param app_name: The name of the app
 
         :returns: A list of User
         """
@@ -41,62 +34,25 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/users"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(list[User], response.json())
 
-    def org_users(self, *, org_name: str) -> list[OrganizationUserResponse]:
-        """Get the users in an org.
+    def teams(self, *, org_name: str, app_name: str) -> list[AppTeamResponse]:
+        """Get the teams for an app.
 
         :param org_name: The name of the organization
+        :param app_name: The name of the app.
 
-        :returns: A list of OrganizationUserResponse
+        :returns: A list of AppTeamResponse
         """
 
-        request_url = self.generate_org_url(org_name=org_name)
-        request_url += "/users"
-
-        response = self.get(request_url)
-
-        return deserialize.deserialize(list[OrganizationUserResponse], response.json())
-
-    def delete_user(self, *, org_name: str, user_name: str) -> None:
-        """Delete a user from an org."""
-
-        request_url = self.generate_org_url(org_name=org_name) + f"/users/{user_name}"
-
-        _ = self.delete(request_url)
-
-    def teams(self, *, org_name: str) -> list[TeamResponse]:
-        """Get the teams in an org.
-
-        :param org_name: The name of the organization
-
-        :returns: A TeamResponse
-        """
-
-        request_url = self.generate_org_url(org_name=org_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/teams"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
-        return deserialize.deserialize(list[TeamResponse], response.json())
-
-    def team_users(self, *, org_name: str, team_name: str) -> list[OrganizationUserResponse]:
-        """Get the users in a team in an org.
-
-        :param org_name: The name of the organization
-        :param team_name: The name of the team
-
-        :returns: A TeamResponse
-        """
-
-        request_url = self.generate_org_url(org_name=org_name)
-        request_url += f"/teams/{team_name}/users"
-
-        response = self.get(request_url)
-
-        return deserialize.deserialize(list[OrganizationUserResponse], response.json())
+        return deserialize.deserialize(list[AppTeamResponse], response.json())
 
     def add_collaborator(
         self,
@@ -129,7 +85,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         if role:
             data["role"] = role.value
 
-        self.post(request_url, data=data)
+        self.http_post(request_url, data=data)
 
     def delete_collaborator(self, *, org_name: str, app_name: str, user_email: str) -> None:
         """Remove a user as a collaborator from an app.
@@ -144,7 +100,7 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/users/{urllib.parse.quote(user_email)}"
 
-        self.delete(request_url)
+        self.http_delete(request_url)
 
     def set_collaborator_permissions(
         self, *, org_name: str, app_name: str, user_email: str, permission: Permission
@@ -167,19 +123,4 @@ class AppCenterAccountClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/users/{urllib.parse.quote(user_email)}"
 
-        self.patch(request_url, data={"permissions": [permission.value]})
-
-    def apps(self, *, org_name: str) -> list[AppResponse]:
-        """Get the apps in an org.
-
-        :param org_name: The name of the organization
-
-        :returns: A list of AppResponse
-        """
-
-        request_url = self.generate_org_url(org_name=org_name)
-        request_url += "/apps"
-
-        response = self.get(request_url)
-
-        return deserialize.deserialize(list[AppResponse], response.json())
+        self.http_patch(request_url, data={"permissions": [permission.value]})

--- a/appcenter/crashes.py
+++ b/appcenter/crashes.py
@@ -42,9 +42,9 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def group_details(self, *, org_name: str, app_name: str, error_group_id: str) -> ErrorGroup:
         """Get the error group details.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str error_group_id: The ID of the error group to get the details for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param error_group_id: The ID of the error group to get the details for
 
         :returns: An ErrorGroup
         """
@@ -61,10 +61,10 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> HandledErrorDetails:
         """Get the error details.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str error_group_id: The ID of the error group to get the details for
-        :param str error_id: The ID of the error to get the details for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param error_group_id: The ID of the error group to get the details for
+        :param error_id: The ID of the error to get the details for
 
         :returns: A HandledErrorDetails
         """
@@ -84,10 +84,10 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         This is the full details that App Center has on a crash. It is not
         parsed due to being different per platform.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str error_group_id: The ID of the error group to get the details for
-        :param str error_id: The ID of the error to get the details for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param error_group_id: The ID of the error group to get the details for
+        :param error_id: The ID of the error to get the details for
 
         :returns: The raw full error info dictionary
         """
@@ -110,11 +110,11 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> None:
         """Get the error group details.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str error_group_id: The ID of the error group to set the annotation on
-        :param str annotation: The annotation text
-        :param ErrorGroupState | None state: The state to set the error group to
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param error_group_id: The ID of the error group to set the annotation on
+        :param annotation: The annotation text
+        :param state: The state to set the error group to
 
         The `state` parameter here does seem somewhat unusual, but it can't be
         helped unfortunately. The API requires that we set the state with the
@@ -154,16 +154,16 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> Iterator[ErrorGroupListItem]:
         """Get the error groups for an app.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param datetime.datetime start_time: The time to start getting error groups from
-        :param datetime.datetime | None end_time: The end time to get error groups from
-        :param str | None version: The version of the app to restrict the search to (if any)
-        :param str | None app_build: The build to restrict the search to (if any)
-        :param ErrorGroupState | None group_state: Set to filter to just this group state (open, closed, ignored)
-        :param str | None error_type: Set to filter to specific types of error (all, unhandledError, handledError)
-        :param str | None order_by: The order by parameter to pass in (this will be encoded for you)
-        :param str | None limit: The max number of results to return per request (should not go past 100)
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param start_time: The time to start getting error groups from
+        :param end_time: The end time to get error groups from
+        :param version: The version of the app to restrict the search to (if any)
+        :param app_build: The build to restrict the search to (if any)
+        :param group_state: Set to filter to just this group state (open, closed, ignored)
+        :param error_type: Set to filter to specific types of error (all, unhandledError, handledError)
+        :param order_by: The order by parameter to pass in (this will be encoded for you)
+        :param limit: The max number of results to return per request (should not go past 100)
 
         :returns: An iterator of ErrorGroupListItem
         """
@@ -235,13 +235,13 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> Iterator[HandledError]:
         """Get the errors in a group.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str error_group_id: The ID of the group to get the errors from
-        :param datetime.datetime | None start_time: The time to start getting error groups from
-        :param datetime.datetime | None end_time: The end time to get error groups from
-        :param str | None model: The device model to restrict the search to (if any)
-        :param str | None operating_system: The OS to restrict the search to (if any)
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param error_group_id: The ID of the group to get the errors from
+        :param start_time: The time to start getting error groups from
+        :param end_time: The end time to get error groups from
+        :param model: The device model to restrict the search to (if any)
+        :param operating_system: The OS to restrict the search to (if any)
 
         :returns: An iterator of HandledError
         """
@@ -297,12 +297,12 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> SymbolUploadBeginResponse:
         """Upload debug symbols
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str symbols_path: The path to the symbols
-        :param str symbol_type: The type of symbols being uploaded
-        :param str | None build_number: The build number (required for Android)
-        :param str | None version: The build version (required for Android)
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param symbols_path: The path to the symbols
+        :param symbol_type: The type of symbols being uploaded
+        :param build_number: The build number (required for Android)
+        :param version: The build version (required for Android)
 
         :raises ValueError: If the build number or version aren't specified and it's an Android upload
 
@@ -336,9 +336,9 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> SymbolUploadEndRequest:
         """Commit a symbol upload operation
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str upload_id: The ID of the symbols upload to commit
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param upload_id: The ID of the symbols upload to commit
 
         :returns: The App Center symbol upload end response
         """
@@ -367,14 +367,14 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> None:
         """Upload debug symbols
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str symbols_path: The path to the symbols
-        :param str symbols_name: The name to use for the symbols (defaults to file basename)
-        :param str symbol_type: The type of symbols being uploaded
-        :param str | None build_number: The build number (required for Android)
-        :param str | None version: The build version (required for Android)
-        :param ProgressCallback | None progress_callback: The upload progress callback
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param symbols_path: The path to the symbols
+        :param symbols_name: The name to use for the symbols (defaults to file basename)
+        :param symbol_type: The type of symbols being uploaded
+        :param build_number: The build number (required for Android)
+        :param version: The build version (required for Android)
+        :param progress_callback: The upload progress callback
 
         For the upload progress callback, this is a callable where the first
         parameter is the number of bytes uploaded, and the second parameter is
@@ -424,9 +424,9 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def _next_link_polished(self, next_link: str, org_name: str, app_name: str) -> str:
         """Polish nextLink string gotten from AppCenter service
 
-        :param str next_link: The nextLink property from a service response when items are queried in batches
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
+        :param next_link: The nextLink property from a service response when items are queried in batches
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
 
         :returns: A polished next link to use on next batch
         """

--- a/appcenter/crashes.py
+++ b/appcenter/crashes.py
@@ -39,17 +39,17 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def __init__(self, token: str, parent_logger: logging.Logger) -> None:
         super().__init__("crashes", token, parent_logger)
 
-    def group_details(self, *, owner_name: str, app_name: str, error_group_id: str) -> ErrorGroup:
+    def group_details(self, *, org_name: str, app_name: str, error_group_id: str) -> ErrorGroup:
         """Get the error group details.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str error_group_id: The ID of the error group to get the details for
 
         :returns: An ErrorGroup
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}"
 
         response = self.get(request_url)
@@ -57,11 +57,11 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         return deserialize.deserialize(ErrorGroup, response.json())
 
     def error_details(
-        self, *, owner_name: str, app_name: str, error_group_id: str, error_id: str
+        self, *, org_name: str, app_name: str, error_group_id: str, error_id: str
     ) -> HandledErrorDetails:
         """Get the error details.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str error_group_id: The ID of the error group to get the details for
         :param str error_id: The ID of the error to get the details for
@@ -69,7 +69,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         :returns: A HandledErrorDetails
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}/errors/{error_id}"
 
         response = self.get(request_url)
@@ -77,14 +77,14 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         return deserialize.deserialize(HandledErrorDetails, response.json())
 
     def error_info_dictionary(
-        self, *, owner_name: str, app_name: str, error_group_id: str, error_id: str
+        self, *, org_name: str, app_name: str, error_group_id: str, error_id: str
     ) -> HandledErrorDetails:
         """Get the full error info dictionary.
 
         This is the full details that App Center has on a crash. It is not
         parsed due to being different per platform.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str error_group_id: The ID of the error group to get the details for
         :param str error_id: The ID of the error to get the details for
@@ -92,7 +92,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         :returns: The raw full error info dictionary
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}/errors/{error_id}/download"
 
         response = self.get(request_url)
@@ -102,7 +102,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def set_annotation(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         error_group_id: str,
         annotation: str,
@@ -110,7 +110,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> None:
         """Get the error group details.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str error_group_id: The ID of the error group to set the annotation on
         :param str annotation: The annotation text
@@ -124,7 +124,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         """
 
         if state is None:
-            request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+            request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
             request_url += f"/errors/errorGroups/{error_group_id}"
 
             response = self.get(request_url)
@@ -132,7 +132,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
             group = deserialize.deserialize(ErrorGroup, response.json())
             state = group.state
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}"
 
         self.patch(request_url, data={"state": state.value, "annotation": annotation})
@@ -141,7 +141,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def get_error_groups(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         start_time: datetime.datetime,
         end_time: datetime.datetime | None = None,
@@ -154,7 +154,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> Iterator[ErrorGroupListItem]:
         """Get the error groups for an app.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param datetime.datetime start_time: The time to start getting error groups from
         :param datetime.datetime | None end_time: The end time to get error groups from
@@ -170,7 +170,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
         # pylint: disable=too-many-locals
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/errors/errorGroups?"
 
         parameters = {"start": start_time.replace(microsecond=0).isoformat()}
@@ -215,7 +215,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
                 break
 
             request_url = appcenter.constants.API_BASE_URL + self._next_link_polished(
-                error_groups.nextLink, owner_name, app_name
+                error_groups.nextLink, org_name, app_name
             )
 
         # pylint: disable=too-many-locals
@@ -225,7 +225,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def errors_in_group(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         error_group_id: str,
         start_time: datetime.datetime | None = None,
@@ -235,7 +235,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> Iterator[HandledError]:
         """Get the errors in a group.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str error_group_id: The ID of the group to get the errors from
         :param datetime.datetime | None start_time: The time to start getting error groups from
@@ -246,7 +246,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         :returns: An iterator of HandledError
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}/errors?"
 
         parameters: dict[str, str] = {}
@@ -282,13 +282,13 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
                 break
 
             request_url = appcenter.constants.API_BASE_URL + self._next_link_polished(
-                errors.nextLink, owner_name, app_name
+                errors.nextLink, org_name, app_name
             )
 
     def begin_symbol_upload(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         symbols_name: str,
         symbol_type: SymbolType,
@@ -297,7 +297,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> SymbolUploadBeginResponse:
         """Upload debug symbols
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str symbols_path: The path to the symbols
         :param str symbol_type: The type of symbols being uploaded
@@ -316,7 +316,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
             if version is None:
                 raise ValueError("The version is required for Android")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/symbol_uploads"
 
         data = {"symbol_type": symbol_type.value, "file_name": symbols_name}
@@ -332,18 +332,18 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         return deserialize.deserialize(SymbolUploadBeginResponse, response.json())
 
     def commit_symbol_upload(
-        self, *, owner_name: str, app_name: str, upload_id: str
+        self, *, org_name: str, app_name: str, upload_id: str
     ) -> SymbolUploadEndRequest:
         """Commit a symbol upload operation
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str upload_id: The ID of the symbols upload to commit
 
         :returns: The App Center symbol upload end response
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/symbol_uploads/{upload_id}"
 
         data = {"status": "committed"}
@@ -356,7 +356,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     def upload_symbols(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         symbols_path: str,
         symbols_name: str | None = None,
@@ -367,7 +367,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
     ) -> None:
         """Upload debug symbols
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str symbols_path: The path to the symbols
         :param str symbols_name: The name to use for the symbols (defaults to file basename)
@@ -391,7 +391,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
             symbols_name = os.path.basename(symbols_path)
 
         begin_upload_response = self.begin_symbol_upload(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             symbols_name=symbols_name,
             symbol_type=symbol_type,
@@ -411,7 +411,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
             )
 
         commit_response = self.commit_symbol_upload(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             upload_id=begin_upload_response.symbol_upload_id,
         )
@@ -421,11 +421,11 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
     # pylint: enable=too-many-arguments
 
-    def _next_link_polished(self, next_link: str, owner_name: str, app_name: str) -> str:
+    def _next_link_polished(self, next_link: str, org_name: str, app_name: str) -> str:
         """Polish nextLink string gotten from AppCenter service
 
         :param str next_link: The nextLink property from a service response when items are queried in batches
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
 
         :returns: A polished next link to use on next batch
@@ -433,9 +433,9 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
         _ = self
 
-        if f"{owner_name}/{app_name}" not in next_link:
-            # For some apps, AppCenter is returning invalid nextLinks without app name and owner, just a // instead.
-            next_link = next_link.replace("//", f"/{owner_name}/{app_name}/", 1)
+        if f"{org_name}/{app_name}" not in next_link:
+            # For some apps, AppCenter is returning invalid nextLinks without app name and org, just a // instead.
+            next_link = next_link.replace("//", f"/{org_name}/{app_name}/", 1)
 
         # AppCenter is returning a nextLink with a /api on the URL which causes the request to fail.
         return next_link.replace("/api", "", 1)

--- a/appcenter/crashes.py
+++ b/appcenter/crashes.py
@@ -52,7 +52,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(ErrorGroup, response.json())
 
@@ -72,7 +72,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}/errors/{error_id}"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(HandledErrorDetails, response.json())
 
@@ -95,7 +95,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}/errors/{error_id}/download"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(dict[str, Any], response.json())
 
@@ -127,7 +127,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
             request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
             request_url += f"/errors/errorGroups/{error_group_id}"
 
-            response = self.get(request_url)
+            response = self.http_get(request_url)
 
             group = deserialize.deserialize(ErrorGroup, response.json())
             state = group.state
@@ -135,7 +135,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/errors/errorGroups/{error_group_id}"
 
-        self.patch(request_url, data={"state": state.value, "annotation": annotation})
+        self.http_patch(request_url, data={"state": state.value, "annotation": annotation})
 
     # pylint: disable=too-many-arguments
     def get_error_groups(
@@ -205,7 +205,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
             self.log.info(f"Fetching page {page} of crash groups")
 
-            response = self.get(request_url)
+            response = self.http_get(request_url)
 
             error_groups = deserialize.deserialize(ErrorGroups, response.json())
 
@@ -272,7 +272,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
             self.log.info(f"Fetching page {page} of crashes for group {error_group_id}")
 
-            response = self.get(request_url)
+            response = self.http_get(request_url)
 
             errors = deserialize.deserialize(HandledErrors, response.json())
 
@@ -327,7 +327,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
         if version:
             data["version"] = version
 
-        response = self.post(request_url, data=data)
+        response = self.http_post(request_url, data=data)
 
         return deserialize.deserialize(SymbolUploadBeginResponse, response.json())
 
@@ -348,7 +348,7 @@ class AppCenterCrashesClient(AppCenterDerivedClient):
 
         data = {"status": "committed"}
 
-        response = self.patch(request_url, data=data)
+        response = self.http_patch(request_url, data=data)
 
         return deserialize.deserialize(SymbolUploadEndRequest, response.json())
 

--- a/appcenter/derived_client.py
+++ b/appcenter/derived_client.py
@@ -148,30 +148,30 @@ class AppCenterDerivedClient:
         """
         return f"{API_BASE_URL}/v{version}"
 
-    def generate_app_url(self, *, version: str = "0.1", owner_name: str, app_name: str) -> str:
+    def generate_app_url(self, *, version: str = "0.1", org_name: str, app_name: str) -> str:
         """Generate a URL to use for querying the API for app info.
 
         :param str version: The API version to hit
-        :param str owner_name: The name of the owner of the app
+        :param str org_name: The name of the org
         :param str app_name: The name of the app
 
         :returns: A generated URL base
         """
 
-        url = self.base_url(version=version) + f"/apps/{owner_name}/{app_name}"
+        url = self.base_url(version=version) + f"/apps/{org_name}/{app_name}"
         self.log.debug(f"Generated URL: {url}")
         return url
 
-    def generate_org_url(self, *, version: str = "0.1", owner_name: str) -> str:
+    def generate_org_url(self, *, version: str = "0.1", org_name: str) -> str:
         """Generate a URL to use for querying the API for org info.
 
         :param str version: The API version to hit
-        :param str owner_name: The name of the org owner
+        :param str org_name: The name of the org
 
         :returns: A generated URL base
         """
 
-        url = self.base_url(version=version) + f"/orgs/{owner_name}"
+        url = self.base_url(version=version) + f"/orgs/{org_name}"
         self.log.debug(f"Generated URL: {url}")
         return url
 

--- a/appcenter/derived_client.py
+++ b/appcenter/derived_client.py
@@ -142,7 +142,7 @@ class AppCenterDerivedClient:
     def base_url(self, *, version: str = "0.1") -> str:
         """Generate the base URL for the API.
 
-        :param str version: The API version to hit
+        :param version: The API version to hit
 
         :returns: The base URL
         """
@@ -151,9 +151,9 @@ class AppCenterDerivedClient:
     def generate_app_url(self, *, version: str = "0.1", org_name: str, app_name: str) -> str:
         """Generate a URL to use for querying the API for app info.
 
-        :param str version: The API version to hit
-        :param str org_name: The name of the org
-        :param str app_name: The name of the app
+        :param version: The API version to hit
+        :param org_name: The name of the org
+        :param app_name: The name of the app
 
         :returns: A generated URL base
         """
@@ -165,8 +165,8 @@ class AppCenterDerivedClient:
     def generate_org_url(self, *, version: str = "0.1", org_name: str) -> str:
         """Generate a URL to use for querying the API for org info.
 
-        :param str version: The API version to hit
-        :param str org_name: The name of the org
+        :param version: The API version to hit
+        :param org_name: The name of the org
 
         :returns: A generated URL base
         """

--- a/appcenter/derived_client.py
+++ b/appcenter/derived_client.py
@@ -185,7 +185,7 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def get(self, url: str) -> requests.Response:
+    def http_get(self, url: str) -> requests.Response:
         """Perform a GET request to a url
 
         :param url: The URL to run the GET on
@@ -207,7 +207,7 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def patch(self, url: str, *, data: Any) -> requests.Response:
+    def http_patch(self, url: str, *, data: Any) -> requests.Response:
         """Perform a PATCH request to a url
 
         :param url: The URL to run the POST on
@@ -229,7 +229,7 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def post(self, url: str, *, data: Any) -> requests.Response:
+    def http_post(self, url: str, *, data: Any) -> requests.Response:
         """Perform a POST request to a url
 
         :param url: The URL to run the POST on
@@ -251,7 +251,7 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def post_raw_data(self, url: str, data: Any) -> requests.Response:
+    def http_post_raw_data(self, url: str, data: Any) -> requests.Response:
         """Perform a POST request to a url
 
         :param url: The URL to run the POST on
@@ -273,7 +273,9 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def post_files(self, url: str, *, files: dict[str, tuple[str, BinaryIO]]) -> requests.Response:
+    def http_post_files(
+        self, url: str, *, files: dict[str, tuple[str, BinaryIO]]
+    ) -> requests.Response:
         """Perform a POST request to a url, sending files
 
         :param url: The URL to run the POST on
@@ -298,7 +300,7 @@ class AppCenterDerivedClient:
         wait=wait_fixed(10),
         stop=stop_after_attempt(3),
     )
-    def delete(self, url: str) -> requests.Response:
+    def http_delete(self, url: str) -> requests.Response:
         """Perform a DELETE request to a url
 
         :param url: The URL to run the DELETE on

--- a/appcenter/models.py
+++ b/appcenter/models.py
@@ -147,7 +147,7 @@ class HandledErrorDetails:
     appLaunchTimestamp: datetime.datetime | None
     carrierName: str | None
     jailbreak: bool | None
-    properties: dict[str, str | None]
+    properties: dict[str, str] | None
 
 
 class ReleaseOrigin(enum.Enum):
@@ -286,7 +286,7 @@ class ReleaseDetailsResponse:
     bundle_identifier: str | None
 
     # Hashes for the packages
-    package_hashes: list[str | None]
+    package_hashes: list[str] | None
 
     # MD5 checksum of the release binary.
     fingerprint: str | None
@@ -582,6 +582,24 @@ class TeamResponse:
 
     # The description of the team
     description: str | None
+
+
+@deserialize.key("identifier", "id")
+class AppTeamResponse:
+    # The unique ID of the team
+    identifier: str
+
+    # The name of the team
+    name: str
+
+    # The display name of the team
+    display_name: str
+
+    # The description of the team
+    description: str | None
+
+    # The permissions the team has
+    permissions: list[Permission]
 
 
 class OwnerType(enum.Enum):

--- a/appcenter/orgs.py
+++ b/appcenter/orgs.py
@@ -1,0 +1,66 @@
+"""App Center account API wrappers."""
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+
+import deserialize
+
+from appcenter.orgs_teams import AppCenterOrgsTeamsClient
+from appcenter.derived_client import AppCenterDerivedClient
+from appcenter.models import (
+    OrganizationUserResponse,
+    AppResponse,
+)
+
+
+class AppCenterOrgsClient(AppCenterDerivedClient):
+    """Wrapper around the App Center org APIs.
+
+    :param token: The authentication token
+    :param parent_logger: The parent logger that we will use for our own logging
+    """
+
+    teams: AppCenterOrgsTeamsClient
+
+    def __init__(self, token: str, parent_logger: logging.Logger) -> None:
+        super().__init__("org", token, parent_logger)
+        self.teams = AppCenterOrgsTeamsClient(token, parent_logger)
+
+    def users(self, *, org_name: str) -> list[OrganizationUserResponse]:
+        """Get the users in an org.
+
+        :param org_name: The name of the organization
+
+        :returns: A list of OrganizationUserResponse
+        """
+
+        request_url = self.generate_org_url(org_name=org_name)
+        request_url += "/users"
+
+        response = self.http_get(request_url)
+
+        return deserialize.deserialize(list[OrganizationUserResponse], response.json())
+
+    def delete_user(self, *, org_name: str, user_name: str) -> None:
+        """Delete a user from an org."""
+
+        request_url = self.generate_org_url(org_name=org_name) + f"/users/{user_name}"
+
+        _ = self.http_delete(request_url)
+
+    def apps(self, *, org_name: str) -> list[AppResponse]:
+        """Get the apps in an org.
+
+        :param org_name: The name of the organization
+
+        :returns: A list of AppResponse
+        """
+
+        request_url = self.generate_org_url(org_name=org_name)
+        request_url += "/apps"
+
+        response = self.http_get(request_url)
+
+        return deserialize.deserialize(list[AppResponse], response.json())

--- a/appcenter/orgs_teams.py
+++ b/appcenter/orgs_teams.py
@@ -1,0 +1,56 @@
+"""App Center account API wrappers."""
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+
+import deserialize
+
+from appcenter.derived_client import AppCenterDerivedClient
+from appcenter.models import (
+    OrganizationUserResponse,
+    TeamResponse,
+)
+
+
+class AppCenterOrgsTeamsClient(AppCenterDerivedClient):
+    """Wrapper around the App Center org APIs.
+
+    :param token: The authentication token
+    :param parent_logger: The parent logger that we will use for our own logging
+    """
+
+    def __init__(self, token: str, parent_logger: logging.Logger) -> None:
+        super().__init__("teams", token, parent_logger)
+
+    def get(self, *, org_name: str) -> list[TeamResponse]:
+        """Get the teams in an org.
+
+        :param org_name: The name of the organization
+
+        :returns: A TeamResponse
+        """
+
+        request_url = self.generate_org_url(org_name=org_name)
+        request_url += "/teams"
+
+        response = self.http_get(request_url)
+
+        return deserialize.deserialize(list[TeamResponse], response.json())
+
+    def users(self, *, org_name: str, team_name: str) -> list[OrganizationUserResponse]:
+        """Get the users in a team in an org.
+
+        :param org_name: The name of the organization
+        :param team_name: The name of the team
+
+        :returns: A TeamResponse
+        """
+
+        request_url = self.generate_org_url(org_name=org_name)
+        request_url += f"/teams/{team_name}/users"
+
+        response = self.http_get(request_url)
+
+        return deserialize.deserialize(list[OrganizationUserResponse], response.json())

--- a/appcenter/tokens.py
+++ b/appcenter/tokens.py
@@ -39,7 +39,7 @@ class AppCenterTokensClient(AppCenterDerivedClient):
         request_url = self.base_url()
         request_url += "/api_tokens"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(list[UserToken], response.json())
 
@@ -55,7 +55,7 @@ class AppCenterTokensClient(AppCenterDerivedClient):
 
         self.log.debug(f"Creating user token name={name}, scope={scope}")
 
-        response = self.post(request_url, data={"description": name, "scope": [scope.value]})
+        response = self.http_post(request_url, data={"description": name, "scope": [scope.value]})
 
         return deserialize.deserialize(UserToken, response.json())
 
@@ -75,4 +75,4 @@ class AppCenterTokensClient(AppCenterDerivedClient):
             self.log.debug(f"Deleting user token={token.identifier}")
             request_url += token.identifier
 
-        _ = self.delete(request_url)
+        _ = self.http_delete(request_url)

--- a/appcenter/versions.py
+++ b/appcenter/versions.py
@@ -56,18 +56,18 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def __init__(self, token: str, parent_logger: logging.Logger) -> None:
         super().__init__("versions", token, parent_logger)
 
-    def recent(self, *, owner_name: str, app_name: str) -> list[BasicReleaseDetailsResponse]:
+    def recent(self, *, org_name: str, app_name: str) -> list[BasicReleaseDetailsResponse]:
         """Get the recent version for each distribution group.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
 
         :returns: A list of BasicReleaseDetailsResponse
         """
 
-        self.log.info(f"Getting recent versions of app: {owner_name}/{app_name}")
+        self.log.info(f"Getting recent versions of app: {org_name}/{app_name}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/recent_releases"
 
         response = self.get(request_url)
@@ -77,14 +77,14 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def all(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         published_only: bool = False,
         scope: str | None = None,
     ) -> Iterator[BasicReleaseDetailsResponse]:
         """Get all (the 100 latest) versions.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param bool published_only: Return only the published releases (defaults to false)
         :param str | None scope: When the scope is 'tester', only includes
@@ -94,9 +94,9 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         :returns: An iterator of BasicReleaseDetailsResponse
         """
 
-        self.log.info(f"Getting versions of app: {owner_name}/{app_name}")
+        self.log.info(f"Getting versions of app: {org_name}/{app_name}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/releases?"
 
         parameters = {"published_only": str(published_only).lower()}
@@ -111,56 +111,56 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         return deserialize.deserialize(list[BasicReleaseDetailsResponse], response.json())
 
     def release_details(
-        self, *, owner_name: str, app_name: str, release_id: int
+        self, *, org_name: str, app_name: str, release_id: int
     ) -> ReleaseDetailsResponse:
         """Get the full release details for a given version.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param int release_id: The ID of the release to get the details for
 
         :returns: The full details for a release
         """
 
-        self.log.info(f"Getting details for: {owner_name}/{app_name} - {release_id}")
+        self.log.info(f"Getting details for: {org_name}/{app_name} - {release_id}")
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/releases/{release_id}?"
 
         response = self.get(request_url)
 
         return deserialize.deserialize(ReleaseDetailsResponse, response.json())
 
-    def release_id_for_version(self, *, owner_name: str, app_name: str, version: str) -> int | None:
+    def release_id_for_version(self, *, org_name: str, app_name: str, version: str) -> int | None:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param bool version: The app version (usually build number)
 
         :returns: The App Center release identifier
         """
 
-        for app_version in self.all(owner_name=owner_name, app_name=app_name):
+        for app_version in self.all(org_name=org_name, app_name=app_name):
             if app_version.version == version:
                 return app_version.identifier
 
         return None
 
-    def latest_commit(self, *, owner_name: str, app_name: str) -> str | None:
+    def latest_commit(self, *, org_name: str, app_name: str) -> str | None:
         """Find the most recent release which has an available commit in it and return the commit hash.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
 
         :returns: The latest commit available on App Center
         """
 
-        self.log.info(f"Getting latest commit for app: {owner_name}/{app_name}")
+        self.log.info(f"Getting latest commit for app: {org_name}/{app_name}")
 
-        for version in self.all(owner_name=owner_name, app_name=app_name):
+        for version in self.all(org_name=org_name, app_name=app_name):
             full_details = self.release_details(
-                owner_name=owner_name, app_name=app_name, release_id=version.identifier
+                org_name=org_name, app_name=app_name, release_id=version.identifier
             )
 
             if full_details.build is None:
@@ -171,16 +171,16 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
 
         return None
 
-    def get_upload_url(self, *, owner_name: str, app_name: str) -> CreateReleaseUploadResponse:
+    def get_upload_url(self, *, org_name: str, app_name: str) -> CreateReleaseUploadResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
 
         :returns: The App Center release identifier
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/uploads/releases"
 
         for attempt in range(3):
@@ -380,18 +380,18 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         return True
 
     def commit_upload(
-        self, *, owner_name: str, app_name: str, upload_id: str
+        self, *, org_name: str, app_name: str, upload_id: str
     ) -> CommitUploadResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str upload_id: The ID of the upload to commit
 
         :returns: The App Center release end response
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/uploads/releases/{upload_id}"
 
         data = {"upload_status": "uploadFinished"}
@@ -413,16 +413,16 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         return deserialize.deserialize(CommitUploadResponse, response.json())
 
     def _wait_for_upload(
-        self, *, owner_name: str, app_name: str, upload_id: str
+        self, *, org_name: str, app_name: str, upload_id: str
     ) -> CommitUploadResponse:
         """Wait for an upload to finish processing
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str upload_id: The ID of the upload to wait for
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/uploads/releases/{upload_id}"
 
         def wait():
@@ -468,7 +468,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def release(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         release_id: int,
         group_id: str,
@@ -477,7 +477,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> ReleaseDestinationResponse:
         """Release a build to a group.
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param int release_id: The release ID of the app
         :param str group_id: The release ID of the group to release to
@@ -487,7 +487,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         :returns: The App Center release identifier
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/releases/{release_id}/groups"
 
         data = {
@@ -515,14 +515,14 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def update_release(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         release_id: int,
         release_update_request: ReleaseUpdateRequest,
     ) -> None:
         """Update a release with new details
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param int release_id: The release ID of the app
         :param ReleaseUpdateRequest release_update_request: The release ID of the group to release to
@@ -530,7 +530,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         :returns: The App Center release identifier
         """
 
-        request_url = self.generate_app_url(owner_name=owner_name, app_name=app_name)
+        request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/releases/{release_id}"
 
         for attempt in range(3):
@@ -550,7 +550,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def upload_build(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         binary_path: str,
         release_notes: str,
@@ -560,7 +560,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> int | None:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str binary_path: The path to the binary to upload
         :param str release_notes: The release notes for the release
@@ -577,9 +577,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         if not os.path.exists(binary_path):
             raise FileNotFoundError(f"Could not find binary: {binary_path}")
 
-        create_release_upload_response = self.get_upload_url(
-            owner_name=owner_name, app_name=app_name
-        )
+        create_release_upload_response = self.get_upload_url(org_name=org_name, app_name=app_name)
 
         success = self.upload_binary(
             create_release_upload_response=create_release_upload_response,
@@ -590,13 +588,13 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
             raise Exception("Failed to upload binary")
 
         self.commit_upload(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             upload_id=create_release_upload_response.identifier,
         )
 
         upload_end_response = self._wait_for_upload(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             upload_id=create_release_upload_response.identifier,
         )
@@ -612,7 +610,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         update_request = ReleaseUpdateRequest(release_notes=release_notes, build=build_info)
 
         self.update_release(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             release_id=upload_end_response.release_distinct_id,
             release_update_request=update_request,
@@ -624,7 +622,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def upload_and_release(
         self,
         *,
-        owner_name: str,
+        org_name: str,
         app_name: str,
         binary_path: str,
         group_id: str,
@@ -636,7 +634,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> ReleaseDetailsResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str owner_name: The name of the app account owner
+        :param str org_name: The name of the organization
         :param str app_name: The name of the app
         :param str binary_path: The path to the binary to upload
         :param str group_id: The ID of the group to release to
@@ -653,7 +651,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         """
 
         release_id = self.upload_build(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             binary_path=binary_path,
             release_notes=release_notes,
@@ -666,13 +664,13 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
             raise Exception("Did not get release ID after upload")
 
         self.release(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             release_id=release_id,
             group_id=group_id,
             notify_testers=notify_testers if notify_testers else False,
         )
 
-        return self.release_details(owner_name=owner_name, app_name=app_name, release_id=release_id)
+        return self.release_details(org_name=org_name, app_name=app_name, release_id=release_id)
 
     # pylint: enable=too-many-arguments

--- a/appcenter/versions.py
+++ b/appcenter/versions.py
@@ -59,8 +59,8 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def recent(self, *, org_name: str, app_name: str) -> list[BasicReleaseDetailsResponse]:
         """Get the recent version for each distribution group.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
 
         :returns: A list of BasicReleaseDetailsResponse
         """
@@ -84,10 +84,10 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> Iterator[BasicReleaseDetailsResponse]:
         """Get all (the 100 latest) versions.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param bool published_only: Return only the published releases (defaults to false)
-        :param str | None scope: When the scope is 'tester', only includes
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param published_only: Return only the published releases (defaults to false)
+        :param scope: When the scope is 'tester', only includes
                                     releases that have been distributed to
                                     groups that the user belongs to.
 
@@ -115,9 +115,9 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> ReleaseDetailsResponse:
         """Get the full release details for a given version.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param int release_id: The ID of the release to get the details for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param release_id: The ID of the release to get the details for
 
         :returns: The full details for a release
         """
@@ -134,9 +134,9 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def release_id_for_version(self, *, org_name: str, app_name: str, version: str) -> int | None:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param bool version: The app version (usually build number)
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param version: The app version (usually build number)
 
         :returns: The App Center release identifier
         """
@@ -150,8 +150,8 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def latest_commit(self, *, org_name: str, app_name: str) -> str | None:
         """Find the most recent release which has an available commit in it and return the commit hash.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
 
         :returns: The latest commit available on App Center
         """
@@ -174,8 +174,8 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     def get_upload_url(self, *, org_name: str, app_name: str) -> CreateReleaseUploadResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
 
         :returns: The App Center release identifier
         """
@@ -207,7 +207,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> SetUploadMetadataResponse | None:
         """Set the metadata for a binary upload
 
-        :param CreateReleaseUploadResponse create_release_upload_response: The response to a `get_upload_url` call
+        :param create_release_upload_response: The response to a `get_upload_url` call
         :param binary_path: The path to the binary to upload
 
         :returns: The upload response if we manage to get one, None otherwise
@@ -255,7 +255,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> SetUploadMetadataResponse | None:
         """Set the metadata for a binary upload
 
-        :param CreateReleaseUploadResponse create_release_upload_response: The response to a `get_upload_url` call
+        :param create_release_upload_response: The response to a `get_upload_url` call
         :param binary_path: The path to the binary to upload
 
         :returns: The upload response if we manage to get one, None otherwise
@@ -290,7 +290,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> UploadCompleteResponse | None:
         """Mark the upload of a binary as finished
 
-        :param CreateReleaseUploadResponse create_release_upload_response: The response to a `get_upload_url` call
+        :param create_release_upload_response: The response to a `get_upload_url` call
 
         :returns: The upload complete response on success, None otherwise.
         """
@@ -327,7 +327,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> bool:
         """Upload a binary
 
-        :param CreateReleaseUploadResponse create_release_upload_response: The response to a `get_upload_url` call
+        :param create_release_upload_response: The response to a `get_upload_url` call
         :param binary_path: The path to the binary to upload
 
         :returns: True on success, False on failure
@@ -384,9 +384,9 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> CommitUploadResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str upload_id: The ID of the upload to commit
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param upload_id: The ID of the upload to commit
 
         :returns: The App Center release end response
         """
@@ -417,9 +417,9 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> CommitUploadResponse:
         """Wait for an upload to finish processing
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str upload_id: The ID of the upload to wait for
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param upload_id: The ID of the upload to wait for
         """
 
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
@@ -477,12 +477,12 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> ReleaseDestinationResponse:
         """Release a build to a group.
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param int release_id: The release ID of the app
-        :param str group_id: The release ID of the group to release to
-        :param bool mandatory_update: Set to True to make this a mandatory update
-        :param bool notify_testers: Set to True to notify testers about this new build
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param release_id: The release ID of the app
+        :param group_id: The release ID of the group to release to
+        :param mandatory_update: Set to True to make this a mandatory update
+        :param notify_testers: Set to True to notify testers about this new build
 
         :returns: The App Center release identifier
         """
@@ -522,10 +522,10 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> None:
         """Update a release with new details
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param int release_id: The release ID of the app
-        :param ReleaseUpdateRequest release_update_request: The release ID of the group to release to
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param release_id: The release ID of the app
+        :param release_update_request: The release ID of the group to release to
 
         :returns: The App Center release identifier
         """
@@ -560,13 +560,13 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> int | None:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str binary_path: The path to the binary to upload
-        :param str release_notes: The release notes for the release
-        :param str | None branch_name: The git branch that the build came from
-        :param str | None commit_hash: The hash of the commit that was just built
-        :param str | None commit_message: The message of the commit that was just built
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param binary_path: The path to the binary to upload
+        :param release_notes: The release notes for the release
+        :param branch_name: The git branch that the build came from
+        :param commit_hash: The hash of the commit that was just built
+        :param commit_message: The message of the commit that was just built
 
         :raises FileNotFoundError: If the supplied binary is not found
         :raises Exception: If we don't get a release ID back after upload
@@ -634,15 +634,15 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
     ) -> ReleaseDetailsResponse:
         """Get the App Center release identifier for the app version (usually build number).
 
-        :param str org_name: The name of the organization
-        :param str app_name: The name of the app
-        :param str binary_path: The path to the binary to upload
-        :param str group_id: The ID of the group to release to
-        :param str release_notes: The release notes for the release
-        :param bool | None notify_testers: Set to True to notify testers about this build
-        :param str | None branch_name: The git branch that the build came from
-        :param str | None commit_hash: The hash of the commit that was just built
-        :param str | None commit_message: The message of the commit that was just built
+        :param org_name: The name of the organization
+        :param app_name: The name of the app
+        :param binary_path: The path to the binary to upload
+        :param group_id: The ID of the group to release to
+        :param release_notes: The release notes for the release
+        :param notify_testers: Set to True to notify testers about this build
+        :param branch_name: The git branch that the build came from
+        :param commit_hash: The hash of the commit that was just built
+        :param commit_message: The message of the commit that was just built
 
         :raises FileNotFoundError: If the supplied binary is not found
         :raises Exception: If we don't get a release ID back after upload

--- a/appcenter/versions.py
+++ b/appcenter/versions.py
@@ -70,7 +70,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += "/recent_releases"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(list[BasicReleaseDetailsResponse], response.json())
 
@@ -106,7 +106,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
 
         request_url += urllib.parse.urlencode(parameters)
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(list[BasicReleaseDetailsResponse], response.json())
 
@@ -127,7 +127,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         request_url = self.generate_app_url(org_name=org_name, app_name=app_name)
         request_url += f"/releases/{release_id}?"
 
-        response = self.get(request_url)
+        response = self.http_get(request_url)
 
         return deserialize.deserialize(ReleaseDetailsResponse, response.json())
 
@@ -186,7 +186,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in get_upload_url")
             try:
-                response = self.post(request_url, data={})
+                response = self.http_post(request_url, data={})
                 if response.ok:
                     break
             except Exception as ex:
@@ -233,7 +233,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in set_upload_metadata")
             try:
-                response = self.post(request_url, data={})
+                response = self.http_post(request_url, data={})
                 if response.ok:
                     return deserialize.deserialize(SetUploadMetadataResponse, response.json())
             except Exception as ex:
@@ -272,7 +272,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in _upload_chunk")
             try:
-                response = self.post_raw_data(url=request_url, data=chunk)
+                response = self.http_post_raw_data(url=request_url, data=chunk)
                 if response.ok:
                     return deserialize.deserialize(ChunkUploadResponse, response.json())
             except Exception as ex:
@@ -306,7 +306,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in _mark_upload_finished")
             try:
-                response = self.post_raw_data(request_url, data=None)
+                response = self.http_post_raw_data(request_url, data=None)
                 if response.ok:
                     return deserialize.deserialize(UploadCompleteResponse, response.json())
             except Exception as ex:
@@ -399,7 +399,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting patch {attempt}/3 in commit_upload")
             try:
-                response = self.patch(request_url, data=data)
+                response = self.http_patch(request_url, data=data)
                 if response.ok:
                     break
             except Exception as ex:
@@ -431,7 +431,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
 
         while True:
             self.log.info("Checking upload status...")
-            response = self.get(request_url)
+            response = self.http_get(request_url)
 
             if not response.ok:
                 wait()
@@ -499,7 +499,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting post {attempt}/3 in release")
             try:
-                response = self.post(request_url, data=data)
+                response = self.http_post(request_url, data=data)
                 if response.ok:
                     break
             except Exception as ex:
@@ -536,7 +536,7 @@ class AppCenterVersionsClient(AppCenterDerivedClient):
         for attempt in range(3):
             self.log.debug(f"Attempting patch {attempt}/3 in update_release")
             try:
-                response = self.patch(request_url, data=release_update_request.json())
+                response = self.http_patch(request_url, data=release_update_request.json())
                 if response.ok:
                     break
             except Exception as ex:

--- a/tests/test_appcenter.py
+++ b/tests/test_appcenter.py
@@ -71,7 +71,7 @@ def get_from_keychain() -> str | None:
 def get_tokens() -> list[str]:
     """Get the tokens for authentication.
 
-    :returns: The owner name, app name and token as a tuple.
+    :returns: The org name, app name and token as a tuple.
     """
     details = get_from_keychain()
 
@@ -82,10 +82,10 @@ def get_tokens() -> list[str]:
 
 
 @pytest.fixture(scope="session")
-def owner_name() -> str:
-    """Get the owner name.
+def org_name() -> str:
+    """Get the org name.
 
-    :returns: The owner name
+    :returns: The org name
     """
     return get_tokens()[0]
 
@@ -108,7 +108,7 @@ def token() -> str:
     return get_tokens()[2]
 
 
-def test_construction(owner_name: str, app_name: str, token: str):
+def test_construction(org_name: str, app_name: str, token: str):
     """Test construction."""
     client = appcenter.AppCenterClient(access_token=token)
     start_time = datetime.datetime.now() - datetime.timedelta(days=10)
@@ -117,14 +117,14 @@ def test_construction(owner_name: str, app_name: str, token: str):
     error_group_batch_count = 0
 
     for group in client.crashes.get_error_groups(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         start_time=start_time,
         order_by="count desc",
         limit=1,
     ):
         group_details = client.crashes.group_details(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             error_group_id=group.errorGroupId,
         )
@@ -132,7 +132,7 @@ def test_construction(owner_name: str, app_name: str, token: str):
         assert group_details is not None
 
         errors = client.crashes.errors_in_group(
-            owner_name=owner_name,
+            org_name=org_name,
             app_name=app_name,
             start_time=start_time,
             error_group_id=group.errorGroupId,
@@ -142,7 +142,7 @@ def test_construction(owner_name: str, app_name: str, token: str):
         for error in errors:
             assert error.errorId is not None
             error_details = client.crashes.error_details(
-                owner_name=owner_name,
+                org_name=org_name,
                 app_name=app_name,
                 error_group_id=group.errorGroupId,
                 error_id=error.errorId,
@@ -150,7 +150,7 @@ def test_construction(owner_name: str, app_name: str, token: str):
             assert error_details is not None
 
             full_details = client.crashes.error_info_dictionary(
-                owner_name=owner_name,
+                org_name=org_name,
                 app_name=app_name,
                 error_group_id=group.errorGroupId,
                 error_id=error.errorId,
@@ -168,64 +168,64 @@ def test_construction(owner_name: str, app_name: str, token: str):
             break
 
 
-def test_recent(owner_name: str, app_name: str, token: str):
+def test_recent(org_name: str, app_name: str, token: str):
     """Test recent."""
     client = appcenter.AppCenterClient(access_token=token)
-    recent_builds = client.versions.recent(owner_name=owner_name, app_name=app_name)
+    recent_builds = client.versions.recent(org_name=org_name, app_name=app_name)
     for build in recent_builds:
         print(build)
 
 
-def test_versions(owner_name: str, app_name: str, token: str):
+def test_versions(org_name: str, app_name: str, token: str):
     """Test recent."""
     client = appcenter.AppCenterClient(access_token=token)
-    builds = client.versions.all(owner_name=owner_name, app_name=app_name)
+    builds = client.versions.all(org_name=org_name, app_name=app_name)
     for build in builds:
         print(build)
 
 
-def test_release_id(owner_name: str, app_name: str, token: str):
+def test_release_id(org_name: str, app_name: str, token: str):
     """Test release id check."""
     client = appcenter.AppCenterClient(access_token=token)
     release_id = client.versions.release_id_for_version(
-        owner_name=owner_name, app_name=app_name, version="2917241"
+        org_name=org_name, app_name=app_name, version="2917241"
     )
     print(release_id)
 
 
-def test_release_details(owner_name: str, app_name: str, token: str):
+def test_release_details(org_name: str, app_name: str, token: str):
     """Test release details."""
     client = appcenter.AppCenterClient(access_token=token)
-    recent_builds = client.versions.recent(owner_name=owner_name, app_name=app_name)
+    recent_builds = client.versions.recent(org_name=org_name, app_name=app_name)
     build = recent_builds[0]
     full_details = client.versions.release_details(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         release_id=build.identifier,
     )
     print(full_details)
 
 
-def test_latest_commit(owner_name: str, app_name: str, token: str):
+def test_latest_commit(org_name: str, app_name: str, token: str):
     """Test release details."""
     client = appcenter.AppCenterClient(access_token=token)
-    commit_hash = client.versions.latest_commit(owner_name=owner_name, app_name=app_name)
+    commit_hash = client.versions.latest_commit(org_name=org_name, app_name=app_name)
     assert commit_hash is not None
 
 
-def test_release_counts(owner_name: str, app_name: str, token: str):
+def test_release_counts(org_name: str, app_name: str, token: str):
     """Test release details."""
     client = appcenter.AppCenterClient(access_token=token)
-    recent_builds = client.versions.recent(owner_name=owner_name, app_name=app_name)
+    recent_builds = client.versions.recent(org_name=org_name, app_name=app_name)
     build = recent_builds[0]
     full_details = client.versions.release_details(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         release_id=build.identifier,
     )
     assert full_details.destinations is not None
     counts = client.analytics.release_counts(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         releases=[
             appcenter.models.ReleaseWithDistributionGroup(
@@ -236,14 +236,14 @@ def test_release_counts(owner_name: str, app_name: str, token: str):
     print(counts)
 
 
-def test_upload(owner_name: str, token: str):
+def test_upload(org_name: str, token: str):
     """Test upload."""
     ipa_path = "/path/to/some.ipa"
     if not os.path.exists(ipa_path):
         return
     client = appcenter.AppCenterClient(access_token=token)
     release_id = client.versions.upload_build(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name="UploadTestApp",
         binary_path=ipa_path,
         release_notes="These are some release notes",
@@ -254,7 +254,7 @@ def test_upload(owner_name: str, token: str):
     assert release_id is not None
 
 
-def test_symbol_upload(owner_name: str, token: str):
+def test_symbol_upload(org_name: str, token: str):
     """Test symbol."""
     symbols_path = "/path/to/some.dSYM.zip"
 
@@ -263,7 +263,7 @@ def test_symbol_upload(owner_name: str, token: str):
 
     client = appcenter.AppCenterClient(access_token=token)
     client.crashes.upload_symbols(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name="UploadTestApp",
         version="0.1",
         build_number="123",
@@ -272,7 +272,7 @@ def test_symbol_upload(owner_name: str, token: str):
     )
 
 
-def test_annotations(owner_name: str, app_name: str, token: str):
+def test_annotations(org_name: str, app_name: str, token: str):
     """Test construction."""
     client = appcenter.AppCenterClient(access_token=token)
 
@@ -280,7 +280,7 @@ def test_annotations(owner_name: str, app_name: str, token: str):
     annotation = str(uuid.uuid4())
 
     for result in client.crashes.get_error_groups(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         start_time=datetime.datetime.now() - datetime.timedelta(days=14),
         order_by="count desc",
@@ -292,14 +292,14 @@ def test_annotations(owner_name: str, app_name: str, token: str):
     assert group_id is not None
 
     client.crashes.set_annotation(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         error_group_id=group_id,
         annotation=annotation,
     )
 
     details = client.crashes.group_details(
-        owner_name=owner_name,
+        org_name=org_name,
         app_name=app_name,
         error_group_id=group_id,
     )
@@ -307,10 +307,10 @@ def test_annotations(owner_name: str, app_name: str, token: str):
     assert details.annotation == annotation
 
 
-def test_users(owner_name: str, app_name: str, token: str):
+def test_users(org_name: str, app_name: str, token: str):
     """Test construction."""
     client = appcenter.AppCenterClient(access_token=token)
-    users = client.account.users(owner_name=owner_name, app_name=app_name)
+    users = client.account.users(org_name=org_name, app_name=app_name)
 
     assert len(users) > 0
 
@@ -366,24 +366,24 @@ def test_create_delete_tokens(token: str):
     client.tokens.delete_user_token(new_token)
 
 
-def test_get_teams(owner_name: str, token: str):
+def test_get_teams(org_name: str, token: str):
     """Test get teams"""
     client = appcenter.AppCenterClient(access_token=token)
-    teams = client.account.teams(owner_name=owner_name)
+    teams = client.account.teams(org_name=org_name)
     assert len(teams) != 0
 
 
-def test_get_team_users(owner_name: str, token: str):
+def test_get_team_users(org_name: str, token: str):
     """Test get teams"""
     client = appcenter.AppCenterClient(access_token=token)
-    teams = client.account.teams(owner_name=owner_name)
+    teams = client.account.teams(org_name=org_name)
     team = teams[0]
-    users = client.account.team_users(owner_name=owner_name, team_name=team.name)
+    users = client.account.team_users(org_name=org_name, team_name=team.name)
     assert len(users) != 0
 
 
-def test_get_apps(owner_name: str, token: str):
+def test_get_apps(org_name: str, token: str):
     """Test get apps"""
     client = appcenter.AppCenterClient(access_token=token)
-    apps = client.account.apps(owner_name=owner_name)
+    apps = client.account.apps(org_name=org_name)
     assert len(apps) != 0

--- a/tests/test_appcenter.py
+++ b/tests/test_appcenter.py
@@ -310,7 +310,7 @@ def test_annotations(org_name: str, app_name: str, token: str):
 def test_users(org_name: str, app_name: str, token: str):
     """Test construction."""
     client = appcenter.AppCenterClient(access_token=token)
-    users = client.account.users(org_name=org_name, app_name=app_name)
+    users = client.apps.users(org_name=org_name, app_name=app_name)
 
     assert len(users) > 0
 
@@ -369,21 +369,30 @@ def test_create_delete_tokens(token: str):
 def test_get_teams(org_name: str, token: str):
     """Test get teams"""
     client = appcenter.AppCenterClient(access_token=token)
-    teams = client.account.teams(org_name=org_name)
+    teams = client.orgs.teams.get(org_name=org_name)
     assert len(teams) != 0
 
 
 def test_get_team_users(org_name: str, token: str):
     """Test get teams"""
     client = appcenter.AppCenterClient(access_token=token)
-    teams = client.account.teams(org_name=org_name)
+    teams = client.orgs.teams.get(org_name=org_name)
     team = teams[0]
-    users = client.account.team_users(org_name=org_name, team_name=team.name)
+    users = client.orgs.teams.users(org_name=org_name, team_name=team.name)
     assert len(users) != 0
 
 
 def test_get_apps(org_name: str, token: str):
     """Test get apps"""
     client = appcenter.AppCenterClient(access_token=token)
-    apps = client.account.apps(org_name=org_name)
+    apps = client.orgs.apps(org_name=org_name)
     assert len(apps) != 0
+
+
+def test_get_apps_teams(org_name: str, token: str):
+    """Test get apps"""
+    client = appcenter.AppCenterClient(access_token=token)
+    apps = client.orgs.apps(org_name=org_name)
+    assert len(apps) != 0
+    teams = client.apps.teams(org_name=org_name, app_name=apps[0].name)
+    assert len(teams) != 0


### PR DESCRIPTION
We are out of date on various terms and structure of the APIs. This PR fixes several of the following issues:

1. Replaces `owner_name` with `org_name`. The former was used originally, but App Center changed it after we'd published our initial versions of this package.
2. Remove redundant types from doc comments - These weren't always updated so were inconsistent, and obviously, redundant with type information being present.
3. Replace HTTP methods such as `get(...)` and `post(...)` with `http_get(...)` and `http_post(...)` to allow us to have `.get(...)` as a method for the clients. 
4. Replace the "account" client with "apps" and "orgs" to closer match what the API actually does. 